### PR TITLE
Correcting params used in request

### DIFF
--- a/apigClient.js
+++ b/apigClient.js
@@ -93,8 +93,8 @@ apigClientFactory.newClient = function (config) {
         var request = {
             verb: method.toUpperCase(),
             path: pathComponent + uritemplate.parse(pathTemplate).expand(params),
-            headers: params,
-            queryParams: params,
+            headers: additionalParams.headers,
+            queryParams: additionalParams.queryParams,
             body: body
         };
         


### PR DESCRIPTION
Using the params for headers and queryParams as well as in the path causes the values to be duplicated.

I have changed these to use the additionalParams values as in apiGatewayClient.makeRequest