### PR TITLE
fixes #9, headers default to {}

### DIFF
--- a/apigClient.js
+++ b/apigClient.js
@@ -93,7 +93,7 @@ apigClientFactory.newClient = function (config) {
         var request = {
             verb: method.toUpperCase(),
             path: pathComponent + uritemplate.parse(pathTemplate).expand(params),
-            headers: additionalParams.headers,
+            headers: additionalParams.headers || {},
             queryParams: additionalParams.queryParams,
             body: body
         };


### PR DESCRIPTION
If no additionalParams.headers, we should still allow request to set headers

re #9 