### PR TITLE
Correct example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install aws-api-gateway-client
 
 Require module
 ```
-var apigClientFactory = require('aws-api-gateway-client')
+var apigClientFactory = require('aws-api-gateway-client').default;
 ```
 
 Set invokeUrl to config and create a client. For autholization, additional information is required as explained below.


### PR DESCRIPTION
Hi,

In the example code in README.md, the way to ```require``` the module is shown as following:
```
var apigClientFactory = require('aws-api-gateway-client');
```
However, as Babel 6 has changed its way to transpile ```export default```, now we need to do
```
var apigClientFactory = require('aws-api-gateway-client').default;
```

I have corrected the README.md file, so could you take a look please.
Thank you!