### PR TITLE
Allow signing host to be different from the actual Host

### DIFF
--- a/src/apigClient.js
+++ b/src/apigClient.js
@@ -33,6 +33,7 @@ apigClientFactory.newClient = (config) => {
       service: '',
       defaultContentType: 'application/json',
       defaultAcceptType: 'application/json',
+      signingHost: ''
     };
   }
   if (typeof config.accessKey === 'undefined') {
@@ -76,6 +77,7 @@ apigClientFactory.newClient = (config) => {
     endpoint: endpoint,
     defaultContentType: config.defaultContentType,
     defaultAcceptType: config.defaultAcceptType,
+    signingHost: config.signingHost
   };
 
   let authType = 'NONE';

--- a/src/lib/apiGatewayCore/sigV4Client.js
+++ b/src/lib/apiGatewayCore/sigV4Client.js
@@ -185,7 +185,13 @@ sigV4ClientFactory.newClient = function(config) {
     let datetime = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z').replace(/[:\-]|\.\d{3}/g, '');
     headers[X_AMZ_DATE] = datetime;
     let parser = urlParser.parse(awsSigV4Client.endpoint);
-    headers[HOST] = parser.hostname;
+
+    // Check if a different signing host has been set
+    if(config.signingHost !== undefined) {
+        headers[HOST] = config.signingHost;
+    } else {
+        headers[HOST] = parser.hostname;
+    }
 
     let canonicalRequest = buildCanonicalRequest(verb, path, queryParams, headers, body);
     let hashedCanonicalRequest = hashCanonicalRequest(canonicalRequest);


### PR DESCRIPTION
Add the ability to specify a **‘signing host’, different to the actual Host.** This can be useful if the client is connecting to the API Gateway, for example, via  a proxy server, or a load balancer. The API Gateway is unaware of the actual Hostname, and so it still expects the signing host to be it’s own default hostname.

This is obviously a bit of an edge case, but it's necessary for us as we are connecting to the API Gateway through a proxy server. Let me know what you think.