### PR TITLE
Resolves #20 - Adding retry support with axon-retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ var apigClient = apigClientFactory.newClient({
     sessionToken: 'SESSION_TOKEN', //OPTIONAL: If you are using temporary credentials you must include the session token
     region: 'eu-west-1' // OPTIONAL: The region where the API is deployed, by default this parameter is set to us-east-1
     systemClockOffset: 0 // OPTIONAL: An offset value in milliseconds to apply to signing time
+    retries: 4, // OPTIONAL: Number of times to retry before failing. Uses axon-retry plugin.
+    retryCondition: (err) => { // OPTIONAL: Callback to further control if request should be retried.  Uses axon-retry plugin.
+      return err.response.status === 500;
+    }
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "axios": "^0.16.1",
+    "axios-retry": "^1.2.0",
     "crypto-js": "^3.1.9-1",
     "url": "^0.11.0",
     "url-template": "^2.0.8"

--- a/src/apigClient.js
+++ b/src/apigClient.js
@@ -81,6 +81,8 @@ apigClientFactory.newClient = (config) => {
     defaultContentType: config.defaultContentType,
     defaultAcceptType: config.defaultAcceptType,
     systemClockOffset: config.systemClockOffset,
+    retries: config.retries,
+    retryCondition: config.retryCondition,
   };
 
   let authType = 'NONE';
@@ -97,6 +99,8 @@ apigClientFactory.newClient = (config) => {
     endpoint: endpoint,
     defaultContentType: config.defaultContentType,
     defaultAcceptType: config.defaultAcceptType,
+    retries: config.retries,
+    retryCondition: config.retryCondition,
   };
 
   const apiGatewayClient = apiGatewayClientFactory.newClient(

--- a/src/lib/apiGatewayCore/simpleHttpClient.js
+++ b/src/lib/apiGatewayCore/simpleHttpClient.js
@@ -15,6 +15,7 @@
 /* eslint max-len: ["error", 100]*/
 
 import axios from 'axios';
+import axiosRetry from 'axios-retry';
 import utils from './utils';
 
 const simpleHttpClientFactory = {};
@@ -71,14 +72,25 @@ simpleHttpClientFactory.newClient = (config) => {
     if (queryString != '') {
       url += '?' + queryString;
     }
+
     let simpleHttpRequest = {
-      method: verb,
-      url: url,
       headers: headers,
       data: body,
     };
+    if (config.retries !== undefined) {
+      simpleHttpRequest.baseURL = url;
+      let client = axios.create(simpleHttpRequest);
+      axiosRetry(client, {
+        retries: config.retries,
+        retryCondition: config.retryCondition,
+      });
+      return client.request({method: verb});
+    }
+    simpleHttpRequest.method = verb;
+    simpleHttpRequest.url = url;
     return axios(simpleHttpRequest);
   };
+
   return simpleHttpClient;
 };
 

--- a/test/apigClient.test.js
+++ b/test/apigClient.test.js
@@ -9,6 +9,10 @@ const config = {
   accessKey: '00000000000000000000',
   secretKey: '0000000000000000000000000000000000000000',
   apiKey: '0000000000000000000000000000000000000000',
+  retry: 4,
+  retryCondition: (err) => {
+      return err.response.status === 500;
+    },
 };
 
 test('apigClientFactory exists', t => {


### PR DESCRIPTION
Resolves #20:
* Adds retry support if retries configuration is provided
* Existing functionality kept as is if retries is not provided
* Manually tested with custom AWS API Gateway
** With both AWS_IAM auth and no auth
** With retries and retriesCondition, with retries only (new functionality)
** With no retries (existing functionality)
** With GET, POST and PUT HTTP methods