### PR TITLE
Fix body for react-native Android GET requests

### DIFF
--- a/src/lib/apiGatewayCore/sigV4Client.js
+++ b/src/lib/apiGatewayCore/sigV4Client.js
@@ -173,10 +173,8 @@ sigV4ClientFactory.newClient = function(config) {
     }
 
     let body = utils.copy(request.body);
-    // override request body and set to empty when signing GET requests
-    if (body === undefined || verb === 'GET') {
-      body = '';
-    } else {
+    // stringify request body
+    if (body) {
       body = JSON.stringify(body);
     }
 

--- a/src/lib/apiGatewayCore/simpleHttpClient.js
+++ b/src/lib/apiGatewayCore/simpleHttpClient.js
@@ -63,9 +63,6 @@ simpleHttpClientFactory.newClient = (config) => {
     }
 
     let body = utils.copy(request.body);
-    if (body === undefined) {
-      body = '';
-    }
 
     let url = config.endpoint + path;
     let queryString = buildCanonicalQueryString(queryParams);


### PR DESCRIPTION
When using React Native, Android fails because the body must be empty for GET requests.