### PR TITLE
utils.copy support for buffer re #44

### DIFF
--- a/src/lib/apiGatewayCore/utils.js
+++ b/src/lib/apiGatewayCore/utils.js
@@ -59,6 +59,7 @@ const utils = {
   },
   copy: function(obj) {
     if (null === obj || 'object' !== typeof obj) return obj;
+    if (Buffer.isBuffer(obj)) return Buffer.from(obj);
     let copy = obj.constructor();
     let attr = null;
     for (attr in obj) {


### PR DESCRIPTION
this is a super minimal implementation.  we might consider implementing something like lodash or perhaps rely on babel for a ES2015 spread opperator for more rhobust copy implementations.

re #44