### PR TITLE
Removing forceful json.stringify

### DIFF
--- a/dist/lib/apiGatewayCore/sigV4Client.js
+++ b/dist/lib/apiGatewayCore/sigV4Client.js
@@ -193,8 +193,9 @@ sigV4ClientFactory.newClient = function (config) {
     }
 
     var body = _utils2.default.copy(request.body);
-    // stringify request body
-    if (body) {
+    
+    // stringify request body if content type is JSON
+    if (body && headers['Content-Type'] && headers['Content-Type'] === 'application/json') {
       body = JSON.stringify(body);
     }
 

--- a/src/lib/apiGatewayCore/sigV4Client.js
+++ b/src/lib/apiGatewayCore/sigV4Client.js
@@ -179,8 +179,9 @@ sigV4ClientFactory.newClient = function(config) {
     }
 
     let body = utils.copy(request.body);
-    // stringify request body
-    if (body) {
+    
+    // stringify request body if content type JSON
+    if (body && headers['Content-Type'] && headers['Content-Type'] === 'application/json') {
       body = JSON.stringify(body);
     }
 

--- a/src/lib/apiGatewayCore/sigV4Client.js
+++ b/src/lib/apiGatewayCore/sigV4Client.js
@@ -180,7 +180,7 @@ sigV4ClientFactory.newClient = function(config) {
 
     let body = utils.copy(request.body);
     
-    // stringify request body if content type JSON
+    // stringify request body if content type is JSON
     if (body && headers['Content-Type'] && headers['Content-Type'] === 'application/json') {
       body = JSON.stringify(body);
     }

--- a/src/lib/apiGatewayCore/sigV4Client.js
+++ b/src/lib/apiGatewayCore/sigV4Client.js
@@ -179,7 +179,7 @@ sigV4ClientFactory.newClient = function(config) {
     }
 
     let body = utils.copy(request.body);
-    
+
     // stringify request body if content type is JSON
     if (body && headers['Content-Type'] && headers['Content-Type'] === 'application/json') {
       body = JSON.stringify(body);


### PR DESCRIPTION
With the current code in master, data with content-type "application/xml" gets wrapped around with quotes which causes unexpected errors.  The change in this PR will allow the body to be sent "as is" if the content type is not set application/json.