### PR TITLE
Pull in the pre-release of axios v0.19.0 for HTTPS over HTTP proxy fi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "transpile": "babel src -d dist/",
     "prepublish": "npm run lint && npm run transpile",
+    "postinstall": "npm install",
     "lint": "node_modules/eslint/bin/eslint.js src lib *.js",
     "test": "npm run lint && nyc --reporter=text ava",
     "test:watch": "ava --watch"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     }
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0-beta.1",
     "axios-retry": "^3.0.1",
     "crypto-js": "^3.1.9-1",
     "url": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "scripts": {
     "transpile": "babel src -d dist/",
     "prepublish": "npm run lint && npm run transpile",
-    "postinstall": "npm install",
     "lint": "node_modules/eslint/bin/eslint.js src lib *.js",
     "test": "npm run lint && nyc --reporter=text ava",
     "test:watch": "ava --watch"


### PR DESCRIPTION
…x. (#67)

I don't expect this will be merged in the state where it references a beta release of axios, but I wanted to get it out there for discussion. An update to the axios library is necessary for correct handling of HTTPS over HTTP internet proxies. Note that this is by far the most common config for proxying HTTPS traffic.