### PR TITLE
Update utils.js

### DIFF
--- a/dist/lib/apiGatewayCore/utils.js
+++ b/dist/lib/apiGatewayCore/utils.js
@@ -21,6 +21,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
  * permissions and limitations under the License.
  */
 /* eslint max-len: ["error", 100]*/
+var Buffer = require('buffer/').Buffer;
 
 var utils = {
   assertDefined: function assertDefined(object, name) {


### PR DESCRIPTION
The line is added because while we are using this node js library for react native mobile application, this file is giving error because the Buffer element not found. To make buffer available we require "Buffer" node js library.