### PR TITLE
Host configuration for signature calculation when it is different from invokeUrl

### DIFF
--- a/dist/apigClient.js
+++ b/dist/apigClient.js
@@ -55,7 +55,8 @@ apigClientFactory.newClient = function () {
     defaultContentType: 'application/json',
     defaultAcceptType: 'application/json',
     systemClockOffset: 0,
-    headers: {}
+    headers: {},
+    host: undefined
   }, removeEmpty(config));
 
   // extract endpoint and path from url
@@ -74,7 +75,8 @@ apigClientFactory.newClient = function () {
     defaultAcceptType: config.defaultAcceptType,
     systemClockOffset: config.systemClockOffset,
     retries: config.retries,
-    retryCondition: config.retryCondition
+    retryCondition: config.retryCondition,
+    host: config.host
   };
 
   var authType = 'NONE';

--- a/dist/lib/apiGatewayCore/sigV4Client.js
+++ b/dist/lib/apiGatewayCore/sigV4Client.js
@@ -169,6 +169,7 @@ sigV4ClientFactory.newClient = function (config) {
   awsSigV4Client.endpoint = _utils2.default.assertDefined(config.endpoint, 'endpoint');
   awsSigV4Client.retries = config.retries;
   awsSigV4Client.retryCondition = config.retryCondition;
+  awsSigV4Client.host = config.host;
 
   awsSigV4Client.makeRequest = function (request) {
     var verb = _utils2.default.assertDefined(request.verb, 'verb');
@@ -193,7 +194,7 @@ sigV4ClientFactory.newClient = function (config) {
     }
 
     var body = _utils2.default.copy(request.body);
-    
+
     // stringify request body if content type is JSON
     if (body && headers['Content-Type'] && headers['Content-Type'] === 'application/json') {
       body = JSON.stringify(body);
@@ -206,8 +207,13 @@ sigV4ClientFactory.newClient = function (config) {
 
     var datetime = new Date(new Date().getTime() + config.systemClockOffset).toISOString().replace(/\.\d{3}Z$/, 'Z').replace(/[:\-]|\.\d{3}/g, '');
     headers[X_AMZ_DATE] = datetime;
-    var parser = _url2.default.parse(awsSigV4Client.endpoint);
-    headers[HOST] = parser.hostname;
+
+    if (awsSigV4Client.host) {
+      headers[HOST] = awsSigV4Client.host;
+    } else {
+      var parser = _url2.default.parse(awsSigV4Client.endpoint);
+      headers[HOST] = parser.host;
+    }
 
     var canonicalRequest = buildCanonicalRequest(verb, path, queryParams, headers, body);
     var hashedCanonicalRequest = hashCanonicalRequest(canonicalRequest);

--- a/dist/lib/apiGatewayCore/utils.js
+++ b/dist/lib/apiGatewayCore/utils.js
@@ -21,7 +21,6 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
  * permissions and limitations under the License.
  */
 /* eslint max-len: ["error", 100]*/
-var Buffer = require('buffer/').Buffer;
 
 var utils = {
   assertDefined: function assertDefined(object, name) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-api-gateway-client",
-  "version": "0.2.14",
+  "version": "0.2.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-api-gateway-client",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aws-api-gateway-client",
   "version": "0.2.16",
-  "description": "A moduel for AWS API Gateway client",
+  "description": "A module for AWS API Gateway client",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kndt84/aws-api-gateway-client.git"
@@ -20,7 +20,7 @@
   "scripts": {
     "transpile": "babel src -d dist/",
     "prepublish": "npm run lint && npm run transpile",
-    "lint": "node_modules/eslint/bin/eslint.js src lib *.js",
+    "lint": "node node_modules/eslint/bin/eslint.js src lib *.js",
     "test": "npm run lint && nyc --reporter=text ava",
     "test:watch": "ava --watch"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-api-gateway-client",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "A module for AWS API Gateway client",
   "repository": {
     "type": "git",

--- a/src/apigClient.js
+++ b/src/apigClient.js
@@ -42,6 +42,7 @@ apigClientFactory.newClient = (config = {}) => {
     defaultAcceptType: 'application/json',
     systemClockOffset: 0,
     headers: {},
+    host: undefined,
   }, removeEmpty(config));
 
   // extract endpoint and path from url
@@ -60,7 +61,8 @@ apigClientFactory.newClient = (config = {}) => {
     defaultAcceptType: config.defaultAcceptType,
     systemClockOffset: config.systemClockOffset,
     retries: config.retries,
-    retryCondition: config.retryCondition
+    retryCondition: config.retryCondition,
+    host: config.host,
   };
 
   let authType = 'NONE';

--- a/src/lib/apiGatewayCore/sigV4Client.js
+++ b/src/lib/apiGatewayCore/sigV4Client.js
@@ -155,6 +155,7 @@ sigV4ClientFactory.newClient = function(config) {
   awsSigV4Client.endpoint = utils.assertDefined(config.endpoint, 'endpoint');
   awsSigV4Client.retries = config.retries;
   awsSigV4Client.retryCondition = config.retryCondition;
+  awsSigV4Client.host = config.host;
 
   awsSigV4Client.makeRequest = function(request) {
     let verb = utils.assertDefined(request.verb, 'verb');
@@ -193,8 +194,13 @@ sigV4ClientFactory.newClient = function(config) {
     let datetime = new Date(new Date().getTime() + config.systemClockOffset).toISOString()
                    .replace(/\.\d{3}Z$/, 'Z').replace(/[:\-]|\.\d{3}/g, '');
     headers[X_AMZ_DATE] = datetime;
-    let parser = urlParser.parse(awsSigV4Client.endpoint);
-    headers[HOST] = parser.hostname;
+
+    if (awsSigV4Client.host) {
+      headers[HOST] = awsSigV4Client.host;
+    } else {
+      let parser = urlParser.parse(awsSigV4Client.endpoint);
+      headers[HOST] = parser.host;
+    }
 
     let canonicalRequest = buildCanonicalRequest(verb, path, queryParams, headers, body);
     let hashedCanonicalRequest = hashCanonicalRequest(canonicalRequest);


### PR DESCRIPTION
A configuration option for specifying the host is added. When this is specified, it will take precedence over the one in invokeUrl for the purpose of calculating signature. This is needed when API Gateway is accessed through a manually configured CloudFront distribution (e.g., when the same custom domain also needs to point an S3 bucket to serve static files). In this case, invokeUrl should contain the custom domain but the the host parameter should be set to the original API gateway host, in order to match the calculated signature.

lint script also fixed to be able to run from Git Bash on Windows.
