### PR TITLE
Require buffer module in utils.js

### DIFF
--- a/dist/lib/apiGatewayCore/utils.js
+++ b/dist/lib/apiGatewayCore/utils.js
@@ -67,6 +67,7 @@ var utils = {
   },
   copy: function copy(obj) {
     if (null === obj || 'object' !== (typeof obj === 'undefined' ? 'undefined' : _typeof(obj))) return obj;
+    var Buffer = require('buffer').Buffer;
     if (Buffer.isBuffer(obj)) return Buffer.from(obj);
     var copy = obj.constructor();
     var attr = null;

--- a/src/lib/apiGatewayCore/utils.js
+++ b/src/lib/apiGatewayCore/utils.js
@@ -59,6 +59,7 @@ const utils = {
   },
   copy: function(obj) {
     if (null === obj || 'object' !== typeof obj) return obj;
+    var Buffer = require('buffer').Buffer;
     if (Buffer.isBuffer(obj)) return Buffer.from(obj);
     let copy = obj.constructor();
     let attr = null;

--- a/src/lib/apiGatewayCore/utils.js
+++ b/src/lib/apiGatewayCore/utils.js
@@ -59,7 +59,7 @@ const utils = {
   },
   copy: function(obj) {
     if (null === obj || 'object' !== typeof obj) return obj;
-    var Buffer = require('buffer').Buffer;
+    let Buffer = require('buffer').Buffer;
     if (Buffer.isBuffer(obj)) return Buffer.from(obj);
     let copy = obj.constructor();
     let attr = null;


### PR DESCRIPTION
See #47 and #69...

I have re-added this line again to ensure the package doesn't throw an error for React Native.

Was there any reason why it was removed here?
https://github.com/kndt84/aws-api-gateway-client/commit/94268c3091ebb559903e20b6b3dda97ebfba6a67#diff-14466bca8f1921ac0628b073e9a0050eL24