### PR TITLE
Error out when `invokeUrl` is not specified

### DIFF
--- a/src/apigClient.js
+++ b/src/apigClient.js
@@ -46,6 +46,10 @@ apigClientFactory.newClient = (config = {}) => {
 
   // extract endpoint and path from url
   const invokeUrl = config.invokeUrl;
+  if (!invokeUrl) {
+    throw new Error("invokeUrl must be specified!");
+  };
+
   const endpoint = /(^https?:\/\/[^/]+)/g.exec(invokeUrl)[1];
   const pathComponent = invokeUrl.substring(endpoint.length);
 


### PR DESCRIPTION
Otherwise currently it would fail with obscure error

```
TypeError: Cannot read property '1' of null
```

Which can be pretty hard to figure out what exactly is failing.
