### PR TITLE
Added in support to allow mulitple values for a single query parameter

### DIFF
--- a/dist/lib/apiGatewayCore/sigV4Client.js
+++ b/dist/lib/apiGatewayCore/sigV4Client.js
@@ -81,7 +81,13 @@ sigV4ClientFactory.newClient = function (config) {
     var canonicalQueryString = '';
 
     for (var i = 0; i < sortedQueryParams.length; i++) {
-      canonicalQueryString += sortedQueryParams[i] + '=' + fixedEncodeURIComponent(queryParams[sortedQueryParams[i]]) + '&';
+      const queryParamsAsArray = Array.isArray(queryParams[sortedQueryParams[i]]) ?
+        queryParams[sortedQueryParams[i]] :
+        [ queryParams[sortedQueryParams[i]] ];
+
+      queryParamsAsArray.forEach(queryValue => {
+        canonicalQueryString += sortedQueryParams[i] + '=' + fixedEncodeURIComponent(queryValue) + '&';
+      });
     }
 
     return canonicalQueryString.substr(0, canonicalQueryString.length - 1);


### PR DESCRIPTION
This update allows for multiple values to be specified for a single query parameter, as in the following:

```
queryParams: {
      param0: [ 'value1' , 'value2', value3' ],
      param1: 'value4'
}
```
The resulting query string will be something like:

```
?param0=value1&param0=value2&param0=value3&param1=value4
```

This has been tested on an existing use case