### PR TITLE
Fix URI encoding of special characters

### DIFF
--- a/dist/lib/apiGatewayCore/sigV4Client.js
+++ b/dist/lib/apiGatewayCore/sigV4Client.js
@@ -87,9 +87,9 @@ sigV4ClientFactory.newClient = function (config) {
     return canonicalQueryString.substr(0, canonicalQueryString.length - 1);
   }
 
-  function fixedEncodeURIComponent(str) {
-    return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
-      return '%' + c.charCodeAt(0).toString(16);
+  function fixedEncodeURIComponent (str) {
+    return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+      return '%' + c.charCodeAt(0).toString(16).toUpperCase();
     });
   }
 


### PR DESCRIPTION
Update `fixedEncodeURIComponent` in `sigV4Client` to match a generated client from AWS.  This fixes `The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method.` error when using query parameters with special characters, in my case `*`.